### PR TITLE
Use AutoPointer to remove the need for the destroy method

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ ft = ::FFI::Fasttext::Predictor.new("spec/model.bin")
 ft.predict("derp") # => [["__label__3", 0.4375]] // will output the highest probability label and the associated probability in an array
 ft.predict("derp", 3) # => [["__label__3", 0.4375], ["__label__1", 0.396484], ["__label__2", 0.164063]] // will output the top 3 probabilities in an array of arrays
 ft.predict("derp", 10) # => [["__label__3", 0.4375], ["__label__1", 0.396484], ["__label__2", 0.164063]] // output the same as above as there are only 3 categories or if probability < 0
-
-ft.destroy! # The prediction model is dynamically allocated in C code and must be released
 ```
 
 ## Development

--- a/lib/ffi/fasttext.rb
+++ b/lib/ffi/fasttext.rb
@@ -79,13 +79,9 @@ module FFI
 
     class Predictor
       def initialize(model_name)
-        @ptr = ::File.exist?(model_name) ? ::FFI::Fasttext.create(model_name) : ::FFI::Fasttext.create_from_url(model_name)
-        raise "Error loading model" if @ptr.null?
-      end
-
-      def destroy!
-        ::FFI::Fasttext.destroy(@ptr) unless @ptr.nil?
-        @ptr = nil
+        fasttext_ptr = ::File.exist?(model_name) ? ::FFI::Fasttext.create(model_name) : ::FFI::Fasttext.create_from_url(model_name)
+        raise "Error loading model" if fasttext_ptr.null?
+        @ptr = ::FFI::AutoPointer.new(fasttext_ptr, ::FFI::Fasttext.method(:destroy))
       end
 
       def predict(string, number_of_predictions = 1)

--- a/spec/ffi/fasttext_spec.rb
+++ b/spec/ffi/fasttext_spec.rb
@@ -5,10 +5,6 @@ describe ::FFI::Fasttext::Predictor do
   describe "API" do
     let(:filename) { ::File.join(::File.dirname(__FILE__), "..", "model.bin") }
 
-    it "validates #destroy! present" do
-      ::FFI::Fasttext::Predictor.new(filename).must_respond_to :destroy!
-    end
-
     it "validates #predict present" do
       ::FFI::Fasttext::Predictor.new(filename).must_respond_to :predict
     end


### PR DESCRIPTION
Using `::FFI::AutoPointer` removes the need for the `destroy!` method. The `@ptr` member will be automatically destroyed when the `Predictor` instance is garbage-collected.