### PR TITLE
Use std::vector over raw new/delete

### DIFF
--- a/lib/ffi/fasttext/version.rb
+++ b/lib/ffi/fasttext/version.rb
@@ -1,5 +1,5 @@
 module FFI
   module Fasttext
-    VERSION = "0.3.1"
+    VERSION = "0.3.0"
   end
 end

--- a/lib/ffi/fasttext/version.rb
+++ b/lib/ffi/fasttext/version.rb
@@ -1,5 +1,5 @@
 module FFI
   module Fasttext
-    VERSION = "0.3.0"
+    VERSION = "0.3.1"
   end
 end

--- a/vendor/fasttext/matrix.cc
+++ b/vendor/fasttext/matrix.cc
@@ -21,34 +21,12 @@ namespace fasttext {
 Matrix::Matrix() {
   m_ = 0;
   n_ = 0;
-  data_ = nullptr;
 }
 
 Matrix::Matrix(int64_t m, int64_t n) {
   m_ = m;
   n_ = n;
-  data_ = new real[m * n];
-}
-
-Matrix::Matrix(const Matrix& other) {
-  m_ = other.m_;
-  n_ = other.n_;
-  data_ = new real[m_ * n_];
-  for (int64_t i = 0; i < (m_ * n_); i++) {
-    data_[i] = other.data_[i];
-  }
-}
-
-Matrix& Matrix::operator=(const Matrix& other) {
-  Matrix temp(other);
-  m_ = temp.m_;
-  n_ = temp.n_;
-  std::swap(data_, temp.data_);
-  return *this;
-}
-
-Matrix::~Matrix() {
-  delete[] data_;
+  data_.resize(m * n);
 }
 
 void Matrix::zero() {
@@ -130,15 +108,14 @@ void Matrix::l2NormRow(Vector& norms) const {
 void Matrix::save(std::ostream& out) {
   out.write((char*) &m_, sizeof(int64_t));
   out.write((char*) &n_, sizeof(int64_t));
-  out.write((char*) data_, m_ * n_ * sizeof(real));
+  out.write((char*) &data_[0], m_ * n_ * sizeof(real));
 }
 
 void Matrix::load(std::istream& in) {
   in.read((char*) &m_, sizeof(int64_t));
   in.read((char*) &n_, sizeof(int64_t));
-  delete[] data_;
-  data_ = new real[m_ * n_];
-  in.read((char*) data_, m_ * n_ * sizeof(real));
+  data_.resize(m_ * n_);
+  in.read((char*) &data_[0], m_ * n_ * sizeof(real));
 }
 
 }

--- a/vendor/fasttext/matrix.h
+++ b/vendor/fasttext/matrix.h
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <istream>
 #include <ostream>
+#include <vector>
 
 #include "real.h"
 
@@ -23,15 +24,14 @@ class Vector;
 class Matrix {
 
   public:
-    real* data_;
+    std::vector<real> data_;
     int64_t m_;
     int64_t n_;
 
     Matrix();
     Matrix(int64_t, int64_t);
-    Matrix(const Matrix&);
-    Matrix& operator=(const Matrix&);
-    ~Matrix();
+    Matrix(const Matrix&) = default;
+    Matrix& operator=(const Matrix&) = default;
 
     inline const real& at(int64_t i, int64_t j) const {return data_[i * n_ + j];};
     inline real& at(int64_t i, int64_t j) {return data_[i * n_ + j];};

--- a/vendor/fasttext/model.cc
+++ b/vendor/fasttext/model.cc
@@ -34,11 +34,6 @@ Model::Model(std::shared_ptr<Matrix> wi,
   initLog();
 }
 
-Model::~Model() {
-  delete[] t_sigmoid;
-  delete[] t_log;
-}
-
 void Model::setQuantizePointer(std::shared_ptr<QMatrix> qwi,
                                std::shared_ptr<QMatrix> qwo, bool qout) {
   qwi_ = qwi;
@@ -304,7 +299,7 @@ real Model::getLoss() const {
 }
 
 void Model::initSigmoid() {
-  t_sigmoid = new real[SIGMOID_TABLE_SIZE + 1];
+  t_sigmoid.resize(SIGMOID_TABLE_SIZE + 1);
   for (int i = 0; i < SIGMOID_TABLE_SIZE + 1; i++) {
     real x = real(i * 2 * MAX_SIGMOID) / SIGMOID_TABLE_SIZE - MAX_SIGMOID;
     t_sigmoid[i] = 1.0 / (1.0 + std::exp(-x));
@@ -312,7 +307,7 @@ void Model::initSigmoid() {
 }
 
 void Model::initLog() {
-  t_log = new real[LOG_TABLE_SIZE + 1];
+  t_log.resize(LOG_TABLE_SIZE + 1);
   for (int i = 0; i < LOG_TABLE_SIZE + 1; i++) {
     real x = (real(i) + 1e-5) / LOG_TABLE_SIZE;
     t_log[i] = std::log(x);

--- a/vendor/fasttext/model.h
+++ b/vendor/fasttext/model.h
@@ -49,8 +49,8 @@ class Model {
     int32_t osz_;
     real loss_;
     int64_t nexamples_;
-    real* t_sigmoid;
-    real* t_log;
+    std::vector<real> t_sigmoid;
+    std::vector<real> t_log;
     // used for negative sampling:
     std::vector<int32_t> negatives;
     size_t negpos;
@@ -71,7 +71,6 @@ class Model {
   public:
     Model(std::shared_ptr<Matrix>, std::shared_ptr<Matrix>,
           std::shared_ptr<Args>, int32_t);
-    ~Model();
 
     real binaryLogistic(int32_t, bool, real);
     real negativeSampling(int32_t, real);

--- a/vendor/fasttext/productquantizer.cc
+++ b/vendor/fasttext/productquantizer.cc
@@ -117,12 +117,11 @@ void ProductQuantizer::kmeans(const real *x, real* c, int32_t n, int32_t d) {
   for (auto i = 0; i < ksub_; i++) {
     memcpy (&c[i * d], x + perm[i] * d, d * sizeof(real));
   }
-  uint8_t* codes = new uint8_t[n];
+  std::vector<uint8_t> codes(static_cast<size_t>(n));
   for (auto i = 0; i < niter_; i++) {
-    Estep(x, c, codes, d, n);
-    MStep(x, c, codes, d, n);
+    Estep(x, c, &codes[0], d, n);
+    MStep(x, c, &codes[0], d, n);
   }
-  delete [] codes;
 }
 
 void ProductQuantizer::train(int32_t n, const real * x) {
@@ -134,16 +133,15 @@ void ProductQuantizer::train(int32_t n, const real * x) {
   std::iota(perm.begin(), perm.end(), 0);
   auto d = dsub_;
   auto np = std::min(n, max_points_);
-  real* xslice = new real[np * dsub_];
+  std::vector<real> xslice(static_cast<size_t>(np * dsub_));
   for (auto m = 0; m < nsubq_; m++) {
     if (m == nsubq_-1) {d = lastdsub_;}
     if (np != n) {std::shuffle(perm.begin(), perm.end(), rng);}
     for (auto j = 0; j < np; j++) {
-      memcpy (xslice + j * d, x + perm[j] * dim_ + m * dsub_, d * sizeof(real));
+      memcpy (&xslice[0] + j * d, x + perm[j] * dim_ + m * dsub_, d * sizeof(real));
     }
-    kmeans(xslice, get_centroids(m, 0), np, d);
+    kmeans(&xslice[0], get_centroids(m, 0), np, d);
   }
-  delete [] xslice;
 }
 
 real ProductQuantizer::mulcode(const Vector& x, const uint8_t* codes,

--- a/vendor/fasttext/qmatrix.h
+++ b/vendor/fasttext/qmatrix.h
@@ -31,8 +31,8 @@ class QMatrix {
     std::unique_ptr<ProductQuantizer> pq_;
     std::unique_ptr<ProductQuantizer> npq_;
 
-    uint8_t* codes_;
-    uint8_t* norm_codes_;
+    std::vector<uint8_t> codes_;
+    std::vector<uint8_t> norm_codes_;
 
     bool qnorm_;
 
@@ -45,7 +45,11 @@ class QMatrix {
 
     QMatrix();
     QMatrix(const Matrix&, int32_t, bool);
-    ~QMatrix();
+
+    QMatrix(const QMatrix &) = delete;
+    QMatrix& operator = (const QMatrix &) = delete;
+    QMatrix(QMatrix &&) = delete;
+    QMatrix& operator = (QMatrix &&) = delete;
 
     int64_t getM() const;
     int64_t getN() const;

--- a/vendor/fasttext/vector.cc
+++ b/vendor/fasttext/vector.cc
@@ -21,11 +21,7 @@ namespace fasttext {
 
 Vector::Vector(int64_t m) {
   m_ = m;
-  data_ = new real[m];
-}
-
-Vector::~Vector() {
-  delete[] data_;
+  data_.resize(m);
 }
 
 int64_t Vector::size() const {

--- a/vendor/fasttext/vector.h
+++ b/vendor/fasttext/vector.h
@@ -12,6 +12,7 @@
 
 #include <cstdint>
 #include <ostream>
+#include <vector>
 
 #include "real.h"
 
@@ -24,10 +25,14 @@ class Vector {
 
   public:
     int64_t m_;
-    real* data_;
+    std::vector<real> data_;
 
     explicit Vector(int64_t);
-    ~Vector();
+
+    Vector(const Vector&) = default;
+    Vector& operator = (const Vector&) = default;
+    Vector(Vector &&) = default;
+    Vector& operator = (Vector &&) = default;
 
     real& operator[](int64_t);
     const real& operator[](int64_t) const;


### PR DESCRIPTION
Use std::vector over raw new/delete. This also allows us to get rid of some destructors and assignment constructors and operators, or use their compiler defaults.