### PR TITLE
Pause curlstream after receiving data from curl until next fillbuffer

### DIFF
--- a/vendor/fasttext/curlstream.h
+++ b/vendor/fasttext/curlstream.h
@@ -22,11 +22,12 @@ protected:
 private:
   static int writer_callback(char *data, size_t size, size_t count, void* ptr);
   size_t fillbuffer();
-  
+
   CURL *m_http_handle = nullptr;
   CURLM *m_multi_handle = nullptr;
   char m_buffer[CURL_MAX_WRITE_SIZE];
   size_t m_pos = 0, m_size = 0;
+  bool m_curl_request_paused = false;
 };
 
 class CurlStream : private CurlStreambuff, public std::istream {


### PR DESCRIPTION
I'm not sure when this change was rolled out, but when I set some debug comments it was pretty clear that the curl write callback was being called multiple times for each call to curl_multi_perform which was overwrite the buffer with each subsequent call.

I first rewrote this using a vector to dynamically grow, and that could still be a good option, but then I noticed the magic pause code from a write callback and the simple resume call you can use. Seems like a much easier change in the end than rewriting the buffer.

There are some other bugs at play when we deploy this on kube and load with a url. TBD.